### PR TITLE
Revert "Add `furure: true` to _config.yaml to allow posts in the future"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,4 +2,3 @@ theme: jekyll-theme-cayman
 
 title: The Berlin Robotics Meetup
 description: Meet Robotics Professionals and Enthusiasts in an Informal Environment. Have Pizza. Bring Robots.
-future: true


### PR DESCRIPTION
Reverts Robotics-Berlin/Robotics-Berlin.github.io#2 -- future actually hides the post